### PR TITLE
Add var name to example defn macro

### DIFF
--- a/src/n01se/syntax/repl.clj
+++ b/src/n01se/syntax/repl.clj
@@ -67,8 +67,11 @@
 (defrule sig-body
   (cat binding-vec (opt prepost-map) (rep* form)))
 
+(defterminal var-name symbol?)
+
 (defsyntax defn
-  (cap (cat (opt doc-string)
+  (cap (cat var-name
+            (opt doc-string)
             (opt attr-map)
             (alt sig-body
                  (rep+ (list-form sig-body))))


### PR DESCRIPTION
The existing example implementation falls through to the `clojure.core/defn` error message for input like this:

``` clojure
(repl/defn "square" [x] (* x x))
```
