### PR TITLE
Update Clojure version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
             :min-lein-version "2.0.0"
 
             :dependencies [[criterium "0.3.1"]
-                           [org.clojure/clojure "1.6.0"]
+                           [org.clojure/clojure "1.7.0"]
                            [org.clojure/tools.nrepl "0.2.3"]
                            [clojure-complete "0.2.3"]]
 
@@ -16,9 +16,11 @@
             ;; Describe a performance specific test profile
             :test-selectors {:default (complement :perf), :perf :perf}
 
-            :profiles {:1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+            :profiles {:1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
+		       :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
                        :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}}
-            :aliases {"1.6" ["with-profile" "1.6"]
+            :aliases {"1.7" ["with-profile" "1.7"]
+		      "1.6" ["with-profile" "1.6"]
                       "1.5" ["with-profile" "1.5"]}
             ;; Use this to allow YourKit to connect:
             ;; :jvm-opts ["-agentpath:yjp/libyjpagent.so"]


### PR DESCRIPTION
Hi @jclaggett. 

@rahulkavale and I wish to use this library in our project. We have added a profile for version 1.7. We verified that all tests pass. There was one warning, but that isn't new, and appears even with 1.5 and 1.6.

Could you please merge our PR and make a new release?

Cheers!